### PR TITLE
Yaml map sequences

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1,27 +1,27 @@
 NUGET
   remote: http://nuget.org/api/v2
   specs:
-    FAKE (3.14.9)
-    FSharp.Compiler.Service (0.0.82)
-    FSharp.Formatting (2.7.1)
+    FAKE (3.18.1)
+    FSharp.Compiler.Service (0.0.86)
+    FSharp.Formatting (2.7.5)
       FSharp.Compiler.Service (>= 0.0.82)
       FSharpVSPowerTools.Core (>= 1.7.0)
     FSharpVSPowerTools.Core (1.7.0)
       FSharp.Compiler.Service (>= 0.0.81)
-    Microsoft.Bcl (1.1.9)
+    Microsoft.Bcl (1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     Microsoft.Bcl.Build (1.0.21)
-    Microsoft.Net.Http (2.2.28)
-      Microsoft.Bcl (>= 1.1.9)
+    Microsoft.Net.Http (2.2.29)
+      Microsoft.Bcl (>= 1.1.10)
       Microsoft.Bcl.Build (>= 1.0.14)
     NuGet.CommandLine (2.8.3)
     NUnit (2.6.4)
     NUnit.Runners (2.6.4)
-    Octokit (0.6.2)
+    Octokit (0.7.2)
       Microsoft.Net.Http
     SourceLink.Fake (0.4.2)
 GITHUB
   remote: fsharp/FAKE
   specs:
-    modules/Octokit/Octokit.fsx (ddd071eeb73f5644a1f8edd9d870dc4a6c7a71a4)
+    modules/Octokit/Octokit.fsx (3c56beb3a95baeb501a9ff2898e28130ace0265f)
       Octokit

--- a/src/FSharp.Configuration/ProvidedTypes.fs
+++ b/src/FSharp.Configuration/ProvidedTypes.fs
@@ -872,7 +872,8 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
 
 
     static member convType (parameters: Type list) (ty:Type) = 
-        if ty.IsGenericType then 
+        if ty = null then null
+        elif ty.IsGenericType then 
             let args = Array.map (ProvidedSymbolType.convType parameters) (ty.GetGenericArguments())
             ProvidedSymbolType(Generic (ty.GetGenericTypeDefinition()), Array.toList args)  :> Type
         elif ty.HasElementType then 
@@ -941,7 +942,9 @@ type ProvidedSymbolType(kind: SymbolKind, args: Type list) =
         | SymbolKind.Array _ -> typeof<System.Array>
         | SymbolKind.Pointer -> typeof<System.ValueType>
         | SymbolKind.ByRef -> typeof<System.ValueType>
-        | SymbolKind.Generic gty  -> ProvidedSymbolType.convType args gty.BaseType
+        | SymbolKind.Generic gty  -> 
+            if gty.BaseType = null then null else
+            ProvidedSymbolType.convType args gty.BaseType
         | SymbolKind.FSharpTypeAbbreviation _ -> typeof<obj>
 
     override this.GetArrayRank() = (match kind with SymbolKind.Array n -> n | SymbolKind.SDArray -> 1 | _ -> invalidOp "non-array type")

--- a/tests/FSharp.Configuration.Tests/FSharp.Configuration.Tests.fsproj
+++ b/tests/FSharp.Configuration.Tests/FSharp.Configuration.Tests.fsproj
@@ -65,6 +65,7 @@
     <Compile Include="ResXProvider.Tests.fs" />
     <Compile Include="YamlProvider.Tests.fs" />
     <Compile Include="IniFileProvider.Tests.fs" />
+    <None Include="Lists.yaml" />
     <None Include="Sample.ini">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/FSharp.Configuration.Tests/Lists.yaml
+++ b/tests/FSharp.Configuration.Tests/Lists.yaml
@@ -2,13 +2,13 @@
 items:
     - part_no:   A4786
       descrip:   Water Bucket (Filled)
-      price:     1.47
+      price:     147
       quantity:  4
 
     - part_no:   E1628
       descrip:   High Heeled "Ruby" Slippers
       size:      8
-      price:     100.27
+      price:     10027
       quantity:  1
 
 Components:

--- a/tests/FSharp.Configuration.Tests/Lists.yaml
+++ b/tests/FSharp.Configuration.Tests/Lists.yaml
@@ -1,0 +1,42 @@
+﻿
+items:
+    - part_no:   A4786
+      descrip:   Water Bucket (Filled)
+      price:     1.47
+      quantity:  4
+
+    - part_no:   E1628
+      descrip:   High Heeled "Ruby" Slippers
+      size:      8
+      price:     100.27
+      quantity:  1
+
+Components:
+  - Domain: gtalk.devel-xmpp
+    Secret: secret_gtalk
+  - Domain: facebook.devel-xmpp
+    Secret: secret_facebook
+
+EmptyList:
+  -
+    Domain: gtalk.devel-xmpp
+    Secret: secret_gtalk 
+  - Domain: facebook.devel-xmpp
+    Secret: secret_facebook
+
+Authentication:
+  - Type: ldap
+    MapUserId: "uid={0},ou=People"
+  - {Type: sql, MapUserId: "{0}"}
+
+
+Archive:
+  - Type: imap
+    Writeonly: true
+    ConnectionString: "Server=imap.domain.de;Uid=user;Pwd=password;Folder=user.{0}.Chats.Xmpp;"
+  - Type: mysql
+    Writeonly: false
+    ConnectionString: Server=localhost;Database=message_archive;Uid=xmpp;Pwd=password
+  - Type: mssql
+    Writeonly: false
+    ConnectionString: Data Source=server1;Initial Catalog=message_archive;Integrated Security=SSPI;

--- a/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
@@ -219,3 +219,19 @@ Mail:
      pop3Listener.Events
      smtpListener.Events] 
     |> should equal [1; 1; 1; 1]
+
+
+type Lists = YamlConfig<"Lists.yaml">
+
+[<Test>]
+let ``Can load some items``() =
+    let settings = Lists()
+    settings.LoadText """
+items:
+    - part_no:   A4786
+      descrip:   Water Bucket (Filled)
+      price:     1.47
+      quantity:  4
+"""
+    settings.items.Count |> should equal 0
+    settings.Archive.Count |> should equal 3

--- a/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
@@ -224,14 +224,53 @@ Mail:
 type Lists = YamlConfig<"Lists.yaml">
 
 [<Test>]
-let ``Can load some items``() =
+let ``Can load sequence of maps (single item)``() =
     let settings = Lists()
     settings.LoadText """
 items:
+    - part_no:   Test
+      descrip:   Some description
+      price:     3.47
+      quantity:  14
+"""
+    settings.items.Count |> should equal 1
+    settings.items.[0].part_no |> should equal "Test"
+    settings.items.[0].descrip |> should equal "Some description"
+    settings.items.[0].quantity |> should equal 14 
+
+
+[<Test>]
+let ``Can load sequence of maps (multiple items)``() =
+    let settings = Lists()
+    settings.LoadText """
+items:
+    - part_no:   Test
+      descrip:   Some description
+      price:     3.47
+      quantity:  14
     - part_no:   A4786
       descrip:   Water Bucket (Filled)
       price:     1.47
       quantity:  4
+
+    - part_no:   E1628
+      descrip:   High Heeled "Ruby" Slippers
+      size:      8
+      price:     100.27
+      quantity:  1
 """
-    settings.items.Count |> should equal 0
+    settings.items.Count |> should equal 3
+    settings.items.[0].part_no |> should equal "Test"
+    settings.items.[0].descrip |> should equal "Some description"
+    settings.items.[0].quantity |> should equal 14
+    
+    settings.items.[2].part_no |> should equal "E1628"
+    settings.items.[2].descrip |> should equal "High Heeled \"Ruby\" Slippers"
+    settings.items.[2].quantity |> should equal 1
+
+[<Ignore>]
+[<Test>]
+let ``Check that list defaults are OK``() =
+    let settings = Lists()
+    settings.items.Count |> should equal 2
     settings.Archive.Count |> should equal 3

--- a/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
@@ -246,17 +246,17 @@ let ``Can load sequence of maps (multiple items)``() =
 items:
     - part_no:   Test
       descrip:   Some description
-      price:     3.47
+      price:     347
       quantity:  14
     - part_no:   A4786
       descrip:   Water Bucket (Filled)
-      price:     1.47
+      price:     147
       quantity:  4
 
     - part_no:   E1628
       descrip:   High Heeled "Ruby" Slippers
       size:      8
-      price:     100.27
+      price:     10027
       quantity:  1
 """
     settings.items.Count |> should equal 3


### PR DESCRIPTION
This is basically the implementation of https://github.com/fsprojects/FSharp.Configuration/issues/51

But with some major limitations:
 * We only use the first list item for the provided type
 * If you use different items it will probably break one way or another

Some notes:
 * I created `static member CreateResizeArray<'a>(data : 'a seq) :ResizeArray<'a> = ResizeArray<'a>(data)` because I did not find a way/api to call a constructor of a generic type with a provided type parameter.
 * I'm not sure why we sort on update? Why would differently ordered lists not be different?

Please be kind as these are my first experiments with type providers (a painful experience) :)