### PR TITLE
fix nuget dependencies

### DIFF
--- a/FSharp.Configuration.nuspec
+++ b/FSharp.Configuration.nuspec
@@ -14,6 +14,6 @@
     <releaseNotes>@releaseNotes@</releaseNotes>
     <copyright>Copyright 2013</copyright>
     <tags>@tags@</tags>
-    <dependencies />
+    @dependencies@
   </metadata>
 </package>


### PR DESCRIPTION
Moving to SharpYaml as nuget dependencies (instead of lib) broke somewhat Sharp.Configuration dependencies. It must have SharpYaml as nuget dependencies but, in 0.55 after PR it has not.

Fix nuspec template to add correct dependencies.