### PR TITLE
Fix for #79: Ability to change the configured software

### DIFF
--- a/docs/content/AppSettingsProvider.fsx
+++ b/docs/content/AppSettingsProvider.fsx
@@ -62,3 +62,16 @@ Settings.ConfigFileName
 // read a connection string from the config
 Settings.ConnectionStrings.Test
 // [fsi:val it : string = "Server=.;Database=SomeDatabase;Integrated Security=true"]
+
+(**
+
+Using AppSettingsProvider in *.fsx-script
+-----------------------------------------
+
+The default executable is the current project .config. (Which is Fsi.exe.config in F# interactive.)
+How ever, if you want to modify the configuration of some other application, you can do with SelectExecutableFile-method:
+*)
+
+let path = System.IO.Path.Combine [|__SOURCE_DIRECTORY__ ; "bin"; "myProject.exe" |]
+Settings.SelectExecutableFile path
+Settings.Test2

--- a/src/FSharp.Configuration/TypeProviders.Helper.fs
+++ b/src/FSharp.Configuration/TypeProviders.Helper.fs
@@ -184,7 +184,8 @@ let findConfigFile resolutionFolder configFileName =
     if Path.IsPathRooted configFileName then 
         configFileName 
     else 
-        Path.Combine(resolutionFolder, configFileName)
+        let path = configFileName.Split([|@"\"; "/"|], StringSplitOptions.None)
+        [| [|resolutionFolder|]; path|] |> Array.concat |> Path.Combine
 
 let erasedType<'T> assemblyName rootNamespace typeName = 
     ProvidedTypeDefinition(assemblyName, rootNamespace, typeName, Some(typeof<'T>))

--- a/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
@@ -50,15 +50,19 @@ let ``Can return a connection string from the config file``() =
 let ``Can read multiple connection strings from the config file``() =   
     Settings.ConnectionStrings.Test1 |> should not' (equal Settings.ConnectionStrings.Test2)
 
-
-// Can we assert something from a third party component?
-[<Literal>] 
-let fakeConfig = __SOURCE_DIRECTORY__ + @"/../../packages/FAKE/tools/FAKE.Deploy.exe.config"
-type FakeSettings = AppSettings<fakeConfig>
+open System.IO
+type Settings2 = AppSettings<"app.config">
 
 [<Test>] 
 let ``Can read different configuration file``() =
-    let exePath = [| __SOURCE_DIRECTORY__; ".."; ".."; "packages"; "FAKE"; "tools"; "FAKE.Deploy.exe" |]
-                  |> System.IO.Path.Combine |> System.IO.Path.GetFullPath
-    FakeSettings.SelectExecutableFile exePath
-    FakeSettings.ServerName |> should equal "localhost"
+    let exePath = 
+#if INTERACTIVE
+        let basePath = Path.Combine [| __SOURCE_DIRECTORY__ ; "bin"; "Debug" |]
+#else
+        let basePath = 
+            System.Reflection.Assembly.GetExecutingAssembly().Location
+            |> Path.GetDirectoryName
+#endif
+        Path.Combine(basePath, "FSharp.Configuration.Tests.dll") |> System.IO.Path.GetFullPath    
+    Settings2.SelectExecutableFile exePath
+    Settings2.TestBool |> should equal true

--- a/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
@@ -50,3 +50,14 @@ let ``Can return a connection string from the config file``() =
 let ``Can read multiple connection strings from the config file``() =   
     Settings.ConnectionStrings.Test1 |> should not' (equal Settings.ConnectionStrings.Test2)
 
+
+[<Literal>] 
+let fakeConfig = __SOURCE_DIRECTORY__ + @"/../../packages/FAKE/tools/FAKE.Deploy.exe.config"
+type FakeSettings = AppSettings<fakeConfig>
+
+[<Test>] 
+let ``Can read different configuration file``() =
+    let exePath = [| __SOURCE_DIRECTORY__; ".."; ".."; "packages"; "FAKE"; "tools"; "FAKE.Deploy.exe" |]
+                  |> System.IO.Path.Combine |> System.IO.Path.GetFullPath
+    FakeSettings.SelectExecutableFile exePath
+    FakeSettings.ServerName |> should equal "localhost"

--- a/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
@@ -50,19 +50,16 @@ let ``Can return a connection string from the config file``() =
 let ``Can read multiple connection strings from the config file``() =   
     Settings.ConnectionStrings.Test1 |> should not' (equal Settings.ConnectionStrings.Test2)
 
-open System.IO
-type Settings2 = AppSettings<"app.config">
+[<Literal>] 
+let fakeConfig = __SOURCE_DIRECTORY__ + @"/../../packages/FAKE/tools/FAKE.Deploy.exe.config"
+type FakeSettings = AppSettings<fakeConfig>
 
 [<Test>] 
 let ``Can read different configuration file``() =
-    let exePath = 
-#if INTERACTIVE
-        let basePath = Path.Combine [| __SOURCE_DIRECTORY__ ; "bin"; "Debug" |]
-#else
-        let basePath = 
-            System.Reflection.Assembly.GetExecutingAssembly().Location
-            |> Path.GetDirectoryName
+    let exePath = [| __SOURCE_DIRECTORY__; ".."; ".."; "packages"; "FAKE"; "tools"; "FAKE.Deploy.exe" |]
+                  |> System.IO.Path.Combine |> System.IO.Path.GetFullPath
+    FakeSettings.SelectExecutableFile exePath
+
+#if INTERACTIVE //Travis can't handle fakeConfig-directory
+    FakeSettings.ServerName |> should equal "localhost"
 #endif
-        Path.Combine(basePath, "FSharp.Configuration.Tests.dll") |> System.IO.Path.GetFullPath    
-    Settings2.SelectExecutableFile exePath
-    Settings2.TestBool |> should equal true

--- a/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/AppSettingsProvider.Tests.fs
@@ -51,6 +51,7 @@ let ``Can read multiple connection strings from the config file``() =
     Settings.ConnectionStrings.Test1 |> should not' (equal Settings.ConnectionStrings.Test2)
 
 
+// Can we assert something from a third party component?
 [<Literal>] 
 let fakeConfig = __SOURCE_DIRECTORY__ + @"/../../packages/FAKE/tools/FAKE.Deploy.exe.config"
 type FakeSettings = AppSettings<fakeConfig>


### PR DESCRIPTION

Now you can actually use AppSettingsProvider from *.fsx scripts and F# Interactive.
This is example code:

        #I @"./../packages/FSharp.Configuration/lib/net40"
        #r @"./../packages/FSharp.Configuration/lib/net40/FSharp.Configuration.dll"
        #r "System.Configuration.dll"

        type Settings = FSharp.Configuration.AppSettings<"app.config">

        let path = System.IO.Path.Combine [|__SOURCE_DIRECTORY__ ; "bin"; "myProject.exe" |]

        Settings.SelectExecutableFile path

        Settings.MyProperty
