### PR TITLE
Add Path.GetFullPath to the filePath calculation in YamlConfigProvider.

### DIFF
--- a/src/FSharp.Configuration/YamlConfigProvider.fs
+++ b/src/FSharp.Configuration/YamlConfigProvider.fs
@@ -501,6 +501,7 @@ let internal typedYamlConfig (context: Context) =
                               if Path.IsPathRooted filePath 
                               then filePath 
                               else context.ResolutionFolder </> filePath
+                              |> Path.GetFullPath
                           context.WatchFile filePath
                           createTy (File.ReadAllText filePath) readOnly
                 | _ -> failwith "Wrong parameters")


### PR DESCRIPTION
Hi, 

I needed the ability to define relative config file in YamlConfig type provider (YamlConfig< @"..\config.yaml" >), so I did a slight change to the source.  

If it went to the main project it would be great!

Thanks!