### PR TITLE
Added support for data in int64 to YamlConfigProvider

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -19,7 +19,7 @@ NUGET
     NUnit.Runners (2.6.4)
     Octokit (0.7.2)
       Microsoft.Net.Http
-    SharpYaml (1.5.2)
+    SharpYaml (1.5.3)
     SourceLink.Fake (0.4.2)
 GITHUB
   remote: fsharp/FAKE

--- a/src/FSharp.Configuration/YamlConfigProvider.fs
+++ b/src/FSharp.Configuration/YamlConfigProvider.fs
@@ -19,6 +19,7 @@ type Helper () =
 module private Parser =
     type Scalar =
         | Int of int
+        | Int64 of int64
         | String of string
         | TimeSpan of TimeSpan
         | Bool of bool
@@ -32,6 +33,7 @@ module private Parser =
             | null -> String ""
             | :? System.Boolean as b -> Bool b
             | :? System.Int32 as i -> Int i
+            | :? System.Int64 as i -> Int64 i
             | :? System.Double as d -> Float d
             | :? System.String as s ->
                 Scalar.ParseStr s
@@ -39,6 +41,7 @@ module private Parser =
         member x.UnderlyingType = 
             match x with
             | Int x -> x.GetType()
+            | Int64 x -> x.GetType()
             | String x -> x.GetType()
             | Bool x -> x.GetType()
             | TimeSpan x -> x.GetType()
@@ -47,6 +50,7 @@ module private Parser =
         member x.BoxedValue =
             match x with
             | Int x -> box x
+            | Int64 x -> box x
             | String x -> box x
             | TimeSpan x -> box x
             | Bool x -> box x
@@ -223,6 +227,7 @@ module private TypesFactory =
         member x.ToExpr() = 
             match x with
             | Int x -> Expr.Value x
+            | Int64 x -> Expr.Value x
             | String x -> Expr.Value x
             | Bool x -> Expr.Value x
             | Float x -> Expr.Value x

--- a/tests/FSharp.Configuration.Tests/Settings.yaml
+++ b/tests/FSharp.Configuration.Tests/Settings.yaml
@@ -16,6 +16,7 @@
 DB:
   ConnectionString: Data Source=server1;Initial Catalog=Database1;Integrated Security=SSPI;
   NumberOfDeadlockRepeats: 5
+  Id: 21474836470
   DefaultTimeout: 00:05:00.0000000
 JustStuff:
   SomeDoubleValue: 0.5

--- a/tests/FSharp.Configuration.Tests/Settings2.yaml
+++ b/tests/FSharp.Configuration.Tests/Settings2.yaml
@@ -16,6 +16,7 @@
 DB:
   ConnectionString: Data Source=server1;Initial Catalog=Database1;Integrated Security=SSPI;
   NumberOfDeadlockRepeats: 11
+  Id: 21474836470
   DefaultTimeout: 0:00:06:00.0000000
 JustStuff:
   SomeDoubleValue: 0.5

--- a/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
@@ -21,6 +21,12 @@ let ``Can return an int from the settings file``() =
     settings.DB.NumberOfDeadlockRepeats |> should equal 5
 
 [<Test>] 
+let ``Can return an int64 from the settings file``() =   
+    let settings = Settings()
+    settings.DB.Id.GetType() |> should equal typeof<int64>   
+    settings.DB.Id |> should equal 21474836470L
+
+[<Test>] 
 let ``Can return an double from the settings file``() =   
     let settings = Settings()
     settings.JustStuff.SomeDoubleValue.GetType() |> should equal typeof<double>   


### PR DESCRIPTION
This add support for a yaml file like:
   maxintX10: 21474836470
this also requires a bump of yamlsharp from 1.5.2 to 1.5.3 do to https://github.com/xoofx/SharpYaml/issues/14