### PR TITLE
https://github.com/fsprojects/FSharp.Configuration/issues/96

### DIFF
--- a/src/FSharp.Configuration/TypeProviders.Helper.fs
+++ b/src/FSharp.Configuration/TypeProviders.Helper.fs
@@ -229,6 +229,9 @@ module File =
                     | _, content -> return content 
                 finally file.Dispose() 
             | None ->  
+                if attemptsLeft = 0 
+                    then return raise (FileNotFoundException(sprintf "File could not be opened after %d attempts." maxAttempts))
+                
                 printfn "Attempt %d of %d: cannot read %s. Sleep for 1 sec, then retry..." attempt maxAttempts filePath
                 return! sleepAndRun attemptsLeft }
         loop maxAttempts |> Async.RunSynchronously

--- a/src/FSharp.Configuration/TypeProviders.Helper.fs
+++ b/src/FSharp.Configuration/TypeProviders.Helper.fs
@@ -230,7 +230,7 @@ module File =
                 finally file.Dispose() 
             | None ->  
                 if attemptsLeft = 0 
-                    then return raise (FileNotFoundException(sprintf "File could not be opened after %d attempts." maxAttempts))
+                    then return raise (FileNotFoundException(sprintf "File, %s could not be opened after %d attempts." filePath maxAttempts))
                 
                 printfn "Attempt %d of %d: cannot read %s. Sleep for 1 sec, then retry..." attempt maxAttempts filePath
                 return! sleepAndRun attemptsLeft }

--- a/src/FSharp.Configuration/YamlConfigProvider.fs
+++ b/src/FSharp.Configuration/YamlConfigProvider.fs
@@ -423,8 +423,12 @@ type Root () =
         reraise()
     /// Load Yaml config from a file and update itself with it.
     member x.Load (filePath: string) = 
+      try
         filePath |> Helper.File.tryReadNonEmptyTextFile |> x.LoadText
         lastLoadedFrom <- Some filePath
+      with e ->
+        async { errorEvent.Trigger e } |> Async.Start
+        reraise()
     /// Load Yaml config from a file, update itself with it, then start watching it for changes.
     /// If it detects any change, it reloads the file.
     member x.LoadAndWatch (filePath: string) = 


### PR DESCRIPTION
Throws if file is not found or fails to load. `YamlConfigProvider.Load` catches, emits, and reraises the exception per the overloaded `Load(FileStream)` method.

Does this work for everyone? I realize raising an exception could be a breaking change.