### PR TITLE
[YamlConfig] Add TimeStamp tag support

### DIFF
--- a/src/FSharp.Configuration/TypeProviders.Helper.fs
+++ b/src/FSharp.Configuration/TypeProviders.Helper.fs
@@ -124,6 +124,9 @@ module ValueParser =
     let (|DateTime|_|) =  
         tryParseWith (fun x -> DateTime.TryParse(x, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal))
 
+    let (|DateTimeOffset|_|) =
+        tryParseWith (fun x -> DateTimeOffset.TryParse(x, CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal))
+
     let (|Uri|_|) (text: string) = 
         ["http"; "https"; "ftp"; "ftps"; "sftp"; "amqp"; "file"; "ssh"; "tcp"] 
         |> List.tryPick (fun x -> 

--- a/src/FSharp.Configuration/YamlConfigProvider.fs
+++ b/src/FSharp.Configuration/YamlConfigProvider.fs
@@ -22,11 +22,13 @@ module private Parser =
         | Int64 of int64
         | String of string
         | TimeSpan of TimeSpan
+        | TimeStamp of DateTimeOffset
         | Bool of bool
         | Uri of Uri
         | Float of double
         static member ParseStr = function
             | ValueParser.TimeSpan x -> TimeSpan x
+            | ValueParser.DateTimeOffset x -> TimeStamp x
             | ValueParser.Uri x -> Uri x
             | x -> String x
         static member FromObj : obj -> Scalar = function
@@ -45,6 +47,7 @@ module private Parser =
             | String x -> x.GetType()
             | Bool x -> x.GetType()
             | TimeSpan x -> x.GetType()
+            | TimeStamp x -> x.GetType()
             | Uri x -> x.GetType()
             | Float x -> x.GetType()
         member x.BoxedValue =
@@ -53,6 +56,7 @@ module private Parser =
             | Int64 x -> box x
             | String x -> box x
             | TimeSpan x -> box x
+            | TimeStamp x -> box x
             | Bool x -> box x
             | Uri x -> box x
             | Float x -> box x
@@ -235,6 +239,9 @@ module private TypesFactory =
             | TimeSpan x -> 
                 let parse = typeof<TimeSpan>.GetMethod("Parse", [|typeof<string>|])
                 Expr.Call(parse, [Expr.Value (x.ToString())])
+            | TimeStamp x ->
+                let parse = typeof<DateTimeOffset>.GetMethod("Parse", [|typeof<string>|])
+                Expr.Call(parse, [Expr.Value (x.ToString())])
             | Uri x ->
                 let ctr = typeof<Uri>.GetConstructor [|typeof<string>|]
                 Expr.NewObject(ctr, [Expr.Value x.OriginalString])
@@ -392,6 +399,18 @@ type Root () =
     let serializer = 
         let settings = SerializerSettings(EmitDefaultValues = true, EmitTags = false, SortKeyForMapping = false, 
                                           EmitAlias = false, ComparerForKeySorting = null)
+        settings.RegisterSerializer (
+            typeof<DateTimeOffset>,
+            { new ScalarSerializerBase() with
+                member __.ConvertFrom (_, scalar) =
+                    match DateTimeOffset.TryParse (scalar.Value) with
+                    | true, dto -> box dto
+                    | _ -> null
+                member __.ConvertTo ctx =
+                    match ctx.Instance with
+                    | :? DateTimeOffset as dto -> dto.ToString("O")
+                    | _ -> "" })
+
         settings.RegisterSerializer (
             typeof<System.Uri>, 
             { new ScalarSerializerBase() with

--- a/tests/FSharp.Configuration.Tests/Settings.yaml
+++ b/tests/FSharp.Configuration.Tests/Settings.yaml
@@ -20,3 +20,4 @@ DB:
   DefaultTimeout: 00:05:00.0000000
 JustStuff:
   SomeDoubleValue: 0.5
+  SomeTimeStamp: 2001-01-01 12:34:56 +00:00

--- a/tests/FSharp.Configuration.Tests/Settings2.yaml
+++ b/tests/FSharp.Configuration.Tests/Settings2.yaml
@@ -20,3 +20,4 @@ DB:
   DefaultTimeout: 0:00:06:00.0000000
 JustStuff:
   SomeDoubleValue: 0.5
+  SomeTimeStamp: 2001-01-01T12:34:56.0000000+00:00

--- a/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
+++ b/tests/FSharp.Configuration.Tests/YamlProvider.Tests.fs
@@ -32,6 +32,11 @@ let ``Can return a TimeSpan from the settings file``() =
     let settings = Settings()
     Assert.Equal(settings.DB.DefaultTimeout, System.TimeSpan.FromMinutes 5.)
 
+[<Fact>]
+let ``Can return a TimeStamp from the settings file``() =
+    let settings = Settings()
+    Assert.Equal(settings.JustStuff.SomeTimeStamp, System.DateTimeOffset(2001, 01, 01, 12, 34, 56, System.TimeSpan.Zero))
+
 [<Fact>] 
 let ``Can return a list from the settings file``() = 
     let settings = Settings()


### PR DESCRIPTION
Adds basic support for the [TimeStamp tag](http://yaml.org/type/timestamp.html)  in YAML configuration files. Includes a new test to verify that the new type is returned correctly from the sample file, and updates to the `Settings2.yaml` file to make sure it saves correctly as well.

Added the `DateTimeOffset` after `TimeSpan` in the `ParseStr` function so that it does not accidentally parse `TimeSpan` values as times instead.