### PR TITLE
Update FSharp.Core to remove dependency on System.ValueTuple.

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -8,8 +8,7 @@ NUGET
       Mono.Cecil (>= 0.9.6.4)
     FAKE (4.61.2)
     FSharp.Compiler.Service (2.0.0.6)
-    FSharp.Core (4.1.17)
-      System.ValueTuple (>= 4.3)
+    FSharp.Core (4.2.1)
     FSharp.Formatting (2.14.4)
       FSharp.Compiler.Service (2.0.0.6)
       FSharpVSPowerTools.Core (>= 2.3 < 2.4)
@@ -20,8 +19,7 @@ NUGET
     Octokit (0.24)
     SharpYaml (1.6.1)
     SourceLink.Fake (1.1)
-    System.ValueTuple (4.3.1)
 GITHUB
   remote: fsharp/FAKE
-    modules/Octokit/Octokit.fsx (1ada6a9c84aada940bd7e6a7b63c0dc62e2fa56e)
+    modules/Octokit/Octokit.fsx (574f6259c4abec2ae45b8c888aa1bdc9b5d4e842)
       Octokit (>= 0.20)

--- a/src/FSharp.Configuration/FSharp.Configuration.fsproj
+++ b/src/FSharp.Configuration/FSharp.Configuration.fsproj
@@ -105,15 +105,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
-      <ItemGroup>
-        <Reference Include="System.ValueTuple">
-          <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>

--- a/tests/FSharp.Configuration.Tests/FSharp.Configuration.Tests.fsproj
+++ b/tests/FSharp.Configuration.Tests/FSharp.Configuration.Tests.fsproj
@@ -162,15 +162,4 @@
       </ItemGroup>
     </When>
   </Choose>
-  <Choose>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.6'">
-      <ItemGroup>
-        <Reference Include="System.ValueTuple">
-          <HintPath>..\..\packages\System.ValueTuple\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
-          <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>


### PR DESCRIPTION
This project doesn't seem to need it, and removing it might fix #124.

I couldn't update all deps, because latest Expecto is built against .Net 4.6.1 so it couldn't be loaded.