### PR TITLE
Fix isSortable in updateList - incorrectly true when list is empty

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+#### 1.6.0 - 26.01.2020
+* Fix bug triggering exception 'xx_ItemType is not comparable' when updating an empty list
+
 #### 1.5.0 - 15.06.2018
 * Tweak INI File Parser to allow semicolon characters inside string values (thanks [@zakakula](https://github.com/zakaluka)!).
   * NOTE: This will result in comments no longer being valid beside string values, instead comments should go on a line above the key-value pair

--- a/src/FSharp.Configuration/YamlConfigProvider.fs
+++ b/src/FSharp.Configuration/YamlConfigProvider.fs
@@ -181,13 +181,13 @@ module private Parser =
                 if field.FieldType <> fieldType then
                     failwithf "Cannot assign %O to %O." fieldType.Name field.FieldType.Name
 
-                let isComparable (x: obj) = x :? Uri || x :? IComparable
                 let values = field.GetValue target :?> Collections.IEnumerable |> Seq.cast<obj>
+                let itemType = fieldType.GetGenericArguments().[0]
                 // NOTE: another solution would be to make our provided type implement IComparable
                 // On the other side I'm not completely sure why we sort at all.
                 // What if the ordering of the item matters for the user?
-                let isSortable = values |> Seq.forall isComparable
-
+                let isSortable =
+                    itemType.IsSubclassOf(typeof<Uri>) || typeof<IComparable>.IsAssignableFrom(itemType)
                 let sort (xs: obj seq) =
                     xs
                     |> Seq.sortBy (function
@@ -196,7 +196,6 @@ module private Parser =
                        | x -> failwithf "%A is not comparable, so it cannot be included into a list."  x)
                     |> Seq.toList
 
-                let itemType = fieldType.GetGenericArguments().[0]
                 let updaters = makeListItemUpdaters itemType updaters
 
                 let oldValues, newValues =


### PR DESCRIPTION
When a list is empty, it is recognized as sortable, and an attempt is made to sort the updaters' values. This fails when the values aren't comparable.
Use the item type itself and reflection for the sortability criterion instead.